### PR TITLE
Add base_url to image path

### DIFF
--- a/application/views/qslcard/index.php
+++ b/application/views/qslcard/index.php
@@ -105,7 +105,7 @@
 					$user_id = $this->session->userdata('user_id');
 
 					// Build correct image path: userdata/[user_id]/qsl_card/[filename]
-					$image_path = $this->paths->getPathQsl() . '/' . $filename;
+					$image_path = base_url().$this->paths->getPathQsl() . '/' . $filename;
 					?>
 					<div class="waterfall-item">
 						<div class="card h-100">


### PR DESCRIPTION
We need to add the base_url to the image path because otherwise the images cannot be displayed:

![image](https://github.com/user-attachments/assets/0527d43f-1c71-44df-a2ec-e63c053bf5d6)
